### PR TITLE
Revert "chore(deps-dev): bump ts-node-dev from 1.1.8 to 2.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "ts-jest": "^28.0.3",
         "ts-loader": "^9.2.3",
         "ts-node": "^10.0.0",
-        "ts-node-dev": "^2.0.0",
+        "ts-node-dev": "^1.1.8",
         "tsc-alias": "^1.6.7",
         "tsconfig-paths": "^3.10.1",
         "typescript": "~4.5.2"
@@ -12019,20 +12019,20 @@
       }
     },
     "node_modules/ts-node-dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
-      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
+      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.1",
         "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.5",
         "mkdirp": "^1.0.4",
         "resolve": "^1.0.0",
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^10.4.0",
+        "ts-node": "^9.0.0",
         "tsconfig": "^7.0.0"
       },
       "bin": {
@@ -12062,6 +12062,32 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ts-node-dev/node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
       }
     },
     "node_modules/ts-node/node_modules/acorn-walk": {
@@ -21659,20 +21685,20 @@
       }
     },
     "ts-node-dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
-      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
+      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
       "dev": true,
       "requires": {
         "chokidar": "^3.5.1",
         "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.5",
         "mkdirp": "^1.0.4",
         "resolve": "^1.0.0",
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^10.4.0",
+        "ts-node": "^9.0.0",
         "tsconfig": "^7.0.0"
       },
       "dependencies": {
@@ -21683,6 +21709,20 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
+          }
+        },
+        "ts-node": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ts-jest": "^28.0.3",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
-    "ts-node-dev": "^2.0.0",
+    "ts-node-dev": "^1.1.8",
     "tsc-alias": "^1.6.7",
     "tsconfig-paths": "^3.10.1",
     "typescript": "~4.5.2"


### PR DESCRIPTION
Reverts Cridium/cridium-server#44 because it conflicts with the current workspace